### PR TITLE
Add Support for Oracle Autonomous DB

### DIFF
--- a/json-sql
+++ b/json-sql
@@ -1,23 +1,15 @@
 #!/usr/bin/env python3
 
+import cx_Oracle
 import decimal
 import datetime
 import json
-import sqlite3
-import sys
-
+import os
+import platform 
 import pymysql
 import psycopg2
-import cx_Oracle
-import platform 
-import os
-
-# to avoid "TypeError: Object of type datetime is not JSON serializable"
-# per https://stackoverflow.com/a/35870294
-def datetime_handler(x):
-    if isinstance(x, datetime.datetime):
-        return x.isoformat()
-    raise TypeError("Unknown type")
+import sqlite3
+import sys
 
 def jsonable(o):
     if type(o) in [str, int, float, bool, type(None)]:
@@ -47,7 +39,6 @@ def make_table(data, columns):
 
 class DB:
     connection = None
-    db_type = None
 
     def execute_query(self, query_string):
         def cursor_has_results(cursor):
@@ -66,10 +57,7 @@ class DB:
 
     def read_table(self, table_name):
         columns = self._column_names(table_name)
-        if self.__class__.__name__ == 'ORACLEADB':
-            data = self.execute_query("select * from {}".format(table_name))
-        else:
-            data = self.execute_query("select * from {};".format(table_name))
+        data = self.execute_query("select * from {};".format(table_name))
         return make_table(data, columns)
 
     def read_tables(self):
@@ -109,6 +97,11 @@ class ORACLEADB(DB):
         self.connection = cx_Oracle.connect(user, password, tnsname)
         self.schema = schema
    
+    def read_table(self, table_name):
+        columns = self._column_names(table_name)
+        data = self.execute_query("select * from {}".format(table_name))
+        return make_table(data, columns)
+
     def _column_names(self, table_name):
         names = self.execute_query(
             "select column_name from all_tab_columns where table_name = '{}'".format(table_name))
@@ -207,10 +200,10 @@ Example usages:
         json-sql read oracleadb demo MyStr0ngPa$$w0rd DATA demodb_low /projects/resources/instantclient_19_3
 
     Insert data into Oracle Autonomous DB:
-        echo '["insert into table (a,b,c) values (1,2,3)"]' | json-sql query oracleadb demo MyStr0ngPa$$w0rd DATA demodb_low $LD_LIBRARY_PATH
+        echo ["insert into table (a,b,c) values (1,2,3)"] | json-sql query oracleadb demo MyStr0ngPa$$w0rd DATA demodb_low /projects/resources/instantclient_19_3
 
     Insert data into a mysql DB:
-        echo '["insert into table (a,b,c) values(1, 2, 3);"]' | json-sql query mysql user password localhost 3306 db
+        echo ["insert into table (a,b,c) values(1, 2, 3);"] | json-sql query mysql user password localhost 3306 db
 
 Example advanced usage with other programs:
     Read a specific table from a psql DB:
@@ -236,7 +229,7 @@ def main():
         print(json.dumps(db.read()))
     elif method == "query":
         queries = json.load(sys.stdin)
-        print(json.dumps([db.execute_query(query) for query in queries], default=datetime_handler))
+        print(json.dumps([db.execute_query(query) for query in queries], default=jsonable))
     else:
         print(help_message(), end="")
     return

--- a/json-sql
+++ b/json-sql
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 
-import cx_Oracle
-import decimal
+
 import datetime
+import decimal
 import json
 import os
 import platform 
-import pymysql
-import psycopg2
 import sqlite3
 import sys
+
+import cx_Oracle
+import pymysql
+import psycopg2
 
 def jsonable(o):
     if type(o) in [str, int, float, bool, type(None)]:
@@ -88,7 +90,6 @@ class DB:
         return NotImplementedError
 
 class ORACLEADB(DB):
-    schema = None
     def __init__(self, user, password, schema, tnsname, lib_dir=None):
         if os.environ['TNS_ADMIN'] == "":
             raise Exception("Please set the TNS_ADMIN environment variable to the path of your Autonomous DB wallet.")

--- a/json-sql
+++ b/json-sql
@@ -91,6 +91,12 @@ class DB:
 
 class ORACLEADB(DB):
     def __init__(self, user, password, schema, tnsname, lib_dir=None):
+        # check for TNS_ADMIN environment variable
+        # this should be the path to the wallet directory
+        # and must be set. I'm checking it manually and 
+        # raising an exception if it is missing to avoid the 
+        # somewhat misleading and ambiguous exception that Oracle
+        # would otherwise throw (ORA-12154: TNS:could not resolve the connect identifier specified)
         if os.environ['TNS_ADMIN'] == "":
             raise Exception("Please set the TNS_ADMIN environment variable to the path of your Autonomous DB wallet.")
         if lib_dir is not None and platform.platform()[:6] == 'Darwin':

--- a/json-sql
+++ b/json-sql
@@ -191,7 +191,7 @@ CREDENTIALS:
         psql - user password host port database
         mysql - user password host port database
         sqlite3 - filename
-        oracleadb - user password schemaname tnsname path_to_instant_client
+        oracleadb - user password schemaname tnsname path_to_instant_client (optional - used on MacOS, otherwise set ENV var as appropriate)
 
 Example usages:
     Read from a psql DB:

--- a/json-sql
+++ b/json-sql
@@ -1,17 +1,29 @@
 #!/usr/bin/env python3
 
 import decimal
+import datetime
 import json
 import sqlite3
 import sys
 
 import pymysql
 import psycopg2
+import cx_Oracle
+import platform 
+import os
 
+# to avoid "TypeError: Object of type datetime is not JSON serializable"
+# per https://stackoverflow.com/a/35870294
+def datetime_handler(x):
+    if isinstance(x, datetime.datetime):
+        return x.isoformat()
+    raise TypeError("Unknown type")
 
 def jsonable(o):
     if type(o) in [str, int, float, bool, type(None)]:
         return o
+    elif type(o) in [datetime.datetime]:
+        return o.isoformat()
     elif type(o) in [list]:
         return [jsonable(e) for e in o]
     elif type(o) in [dict]:
@@ -35,6 +47,7 @@ def make_table(data, columns):
 
 class DB:
     connection = None
+    db_type = None
 
     def execute_query(self, query_string):
         def cursor_has_results(cursor):
@@ -53,8 +66,10 @@ class DB:
 
     def read_table(self, table_name):
         columns = self._column_names(table_name)
-
-        data = self.execute_query("select * from {};".format(table_name))
+        if self.__class__.__name__ == 'ORACLEADB':
+            data = self.execute_query("select * from {}".format(table_name))
+        else:
+            data = self.execute_query("select * from {};".format(table_name))
         return make_table(data, columns)
 
     def read_tables(self):
@@ -66,7 +81,7 @@ class DB:
 
     @staticmethod
     def get_type(command):
-        TYPES = [SQLITE3, PSQL, MYSQL]
+        TYPES = [SQLITE3, PSQL, MYSQL, ORACLEADB]
         possible_t = [t for t in TYPES if t.__name__ == command.upper()]
 
         if possible_t == []:
@@ -83,6 +98,24 @@ class DB:
     # pylint: disable=no-self-use
     def _table_names(self):
         return NotImplementedError
+
+class ORACLEADB(DB):
+    schema = None
+    def __init__(self, user, password, schema, tnsname, lib_dir=None):
+        if os.environ['TNS_ADMIN'] == "":
+            raise Exception("Please set the TNS_ADMIN environment variable to the path of your Autonomous DB wallet.")
+        if lib_dir is not None and platform.platform()[:6] == 'Darwin':
+            cx_Oracle.init_oracle_client(lib_dir)
+        self.connection = cx_Oracle.connect(user, password, tnsname)
+        self.schema = schema
+   
+    def _column_names(self, table_name):
+        names = self.execute_query(
+            "select column_name from all_tab_columns where table_name = '{}'".format(table_name))
+        return [n[0] for n in names]
+
+    def _table_names(self):
+        return [t[0] for t in self.execute_query("select table_name from all_tables where num_rows > 1 and tablespace_name = '{}'".format(self.schema))]
 
 
 class SQLITE3(DB):
@@ -151,12 +184,14 @@ DB_TYPE:
     psql - PostgreSQL
     mysql - MySQL
     sqlite3 - Sqlite3
+    oracleadb - Oracle Autonomous DB (requires Oracle Instant Client https://www.oracle.com/database/technologies/instant-client.html)
 
 CREDENTIALS:
     The credentials depends on the db type:
         psql - user password host port database
         mysql - user password host port database
         sqlite3 - filename
+        oracleadb - user password schemaname tnsname path_to_instant_client
 
 Example usages:
     Read from a psql DB:
@@ -168,8 +203,14 @@ Example usages:
     Read from a sqlite3 DB:
         json-sql read sqlite3 db.sqlite
 
+    Read from an Oracle Autonomous DB:
+        json-sql read oracleadb demo MyStr0ngPa$$w0rd DATA demodb_low /projects/resources/instantclient_19_3
+
+    Insert data into Oracle Autonomous DB:
+        echo '["insert into table (a,b,c) values (1,2,3)"]' | json-sql query oracleadb demo MyStr0ngPa$$w0rd DATA demodb_low $LD_LIBRARY_PATH
+
     Insert data into a mysql DB:
-        echo ["insert into table (a,b,c) values(1, 2, 3);"] | json-sql query mysql user password localhost 3306 db
+        echo '["insert into table (a,b,c) values(1, 2, 3);"]' | json-sql query mysql user password localhost 3306 db
 
 Example advanced usage with other programs:
     Read a specific table from a psql DB:
@@ -195,7 +236,7 @@ def main():
         print(json.dumps(db.read()))
     elif method == "query":
         queries = json.load(sys.stdin)
-        print(json.dumps([db.execute_query(query) for query in queries]))
+        print(json.dumps([db.execute_query(query) for query in queries], default=datetime_handler))
     else:
         print(help_message(), end="")
     return

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyMySQL==0.10.1
 PyYAML==5.3.1
 unidiff==0.6.0
 xmltodict==0.12.0
+cx_Oracle==8.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ast2json==0.2.1
+cx_Oracle==8.1.0
 genson==1.2.2
 logfmt==0.4
 psycopg2==2.8.6
@@ -6,4 +7,3 @@ PyMySQL==0.10.1
 PyYAML==5.3.1
 unidiff==0.6.0
 xmltodict==0.12.0
-cx_Oracle==8.1.0


### PR DESCRIPTION
This PR adds support for Oracle Autonomous DB. Has been tested on MacOS (Catalina) and Linux. Requires Oracle Instant Client to be installed prior to running (like most Oracle tools). I will follow-up with a blog post on utilization after PR is merged.