### PR TITLE
fix: use compiled binaries for psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ast2json==0.2.1
 cx_Oracle==8.1.0
 genson==1.2.2
 logfmt==0.4
-psycopg2==2.8.6
+psycopg2-binary==2.8.6
 PyMySQL==0.10.1
 PyYAML==5.4
 unidiff==0.6.0


### PR DESCRIPTION
Hey!

While trying to use the library on Mac, I had some issues running `make` as it complained a bit. It suggested to install `psycopg2` from binary instead.

```
error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      running egg_info
      creating /private/var/folders/my/q0q67d6j6ml8xxmgmj2l5yqm0000gn/T/pip-pip-egg-info-yqh3w47i/psycopg2.egg-info
      writing /private/var/folders/my/q0q67d6j6ml8xxmgmj2l5yqm0000gn/T/pip-pip-egg-info-yqh3w47i/psycopg2.egg-info/PKG-INFO
      writing dependency_links to /private/var/folders/my/q0q67d6j6ml8xxmgmj2l5yqm0000gn/T/pip-pip-egg-info-yqh3w47i/psycopg2.egg-info/dependency_links.txt
      writing top-level names to /private/var/folders/my/q0q67d6j6ml8xxmgmj2l5yqm0000gn/T/pip-pip-egg-info-yqh3w47i/psycopg2.egg-info/top_level.txt
      writing manifest file '/private/var/folders/my/q0q67d6j6ml8xxmgmj2l5yqm0000gn/T/pip-pip-egg-info-yqh3w47i/psycopg2.egg-info/SOURCES.txt'
      
      Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).
      
```

Would this make sense to switch to? 🤔 